### PR TITLE
Fix for messages without uppercase letters in them

### DIFF
--- a/src/loudbot.coffee
+++ b/src/loudbot.coffee
@@ -47,7 +47,7 @@ class Loudbot
     text = text.trim()
     words = text.split(' ').length
     isUpperCase = text == text.toUpperCase() and text != text.toLowerCase()
-    numLetters = text.match(/[A-Z ]/g, "").length
+    numLetters = text.match(/[A-Z ]/g, "")?.length || 0
     ratio = numLetters / text.length
     isUpperCase and numLetters >= 8 and ratio > 0.9 and words > 1
 


### PR DESCRIPTION
Solves an issue when the text doesn't contain any uppercase letters.

```
Hubot> [Thu Aug 21 2014 12:31:47 GMT-0700 (PDT)] ERROR TypeError: Cannot read property 'length' of null
  at Loudbot.isLoud (/Users/aaron/workspace/jarvis/node_modules/hubot-loudbot/src/loudbot.coffee:50:5, <js>:59:45)
  at TextListener.module.exports [as callback] (/Users/aaron/workspace/jarvis/node_modules/hubot-loudbot/src/script.coffee:24:15, <js>:13:19)
  at TextListener.Listener.call (/Users/aaron/workspace/jarvis/node_modules/hubot/src/listener.coffee:27:7, <js>:23:14)
  at Robot.receive (/Users/aaron/workspace/jarvis/node_modules/hubot/src/robot.coffee:196:9, <js>:141:33)
  at Shell.Adapter.receive (/Users/aaron/workspace/jarvis/node_modules/hubot/src/adapter.coffee:66:5, <js>:47:25)
  at Interface.Shell.run (/Users/aaron/workspace/jarvis/node_modules/hubot/src/adapters/shell.coffee:41:7, <js>:85:22)
  at Interface.EventEmitter.emit (events.js:96:17)
  at Interface._onLine (readline.js:200:10)
  at Interface._line (readline.js:518:8)
  at Interface._ttyWrite (readline.js:736:14)
  at ReadStream.onkeypress (readline.js:97:10)
  at ReadStream.EventEmitter.emit (events.js:126:20)
  at emitKey (readline.js:1058:12)
  at ReadStream.onData (readline.js:807:7)
  at ReadStream.EventEmitter.emit (events.js:96:17)
  at TTY.onread (net.js:397:14)
```
