### PR TITLE
Bugfix #2 - Bot doesn't actually forget louds as instructed

### DIFF
--- a/src/script.coffee
+++ b/src/script.coffee
@@ -29,4 +29,4 @@ module.exports = (robot) ->
       loudbot.remember text
   
   robot.respond /forget loud (.*)/i, (msg) ->
-    loudbot.forget msg.match[0]
+    loudbot.forget msg.match[1]


### PR DESCRIPTION
Minor issue, the first match is the entire statement matching the regex, followed by any captured values.